### PR TITLE
Fix handling of URL navigation in the "About" dialog.

### DIFF
--- a/Desktop/SharpManager/Views/About.xaml.cs
+++ b/Desktop/SharpManager/Views/About.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -33,7 +35,12 @@ namespace SharpManager.Views
         /// <param name="e">The <see cref="RequestNavigateEventArgs"/> instance containing the event data.</param>
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            System.Diagnostics.Process.Start(e.Uri.ToString());
+            System.Diagnostics.Process.Start(
+                new ProcessStartInfo(e.Uri.ToString())
+                {
+                    UseShellExecute = true
+                }
+            );
         }
 
         private void Window_SourceInitialized(object sender, EventArgs e)

--- a/Desktop/SharpManager/Views/About.xaml.cs
+++ b/Desktop/SharpManager/Views/About.xaml.cs
@@ -35,7 +35,7 @@ namespace SharpManager.Views
         /// <param name="e">The <see cref="RequestNavigateEventArgs"/> instance containing the event data.</param>
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            System.Diagnostics.Process.Start(
+            Process.Start(
                 new ProcessStartInfo(e.Uri.ToString())
                 {
                     UseShellExecute = true


### PR DESCRIPTION
Closes #3

Note: since Windows Vista it is not reliable to use a simple `System.Diagnostics.Process.Start(URI)` any longer if user have alternative browsers installed and registered as default browser. Instead one should encapsulate the URI in `ProcessStartInfo()` which makes sure, that the Shell will handle the request.